### PR TITLE
viteを用いたシミュレーションのビルドの警告に対応

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,14 @@ export default defineConfig({
     rollupOptions: {
       input: getHtmlInputsRecursively(root),
     },
+    chunkSizeWarningLimit: 1500,
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        quietDeps: true,
+      },
+    },
   },
   plugins: [
     viteStaticCopy({

--- a/vite/scss/common.scss
+++ b/vite/scss/common.scss
@@ -1,2 +1,2 @@
 // Import all of Bootstrap's CSS
-@import "bootstrap/scss/bootstrap";
+@use "bootstrap/scss/bootstrap";


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- vite.config.jsにチャンクサイズの上限サイズとcsccファイルの警告無視の設定を追加しました。
- common.csccを警告が出ないように修正しました。

## 本プルリクエストで実施していないこと
- 特になし。

## 関連Issue、参考ページ
- 特になし。
