### PR TITLE
自由落下運動の一時停止ボタンに関連するバグに対応

### DIFF
--- a/vite/simulations/free-fall/js/ball.js
+++ b/vite/simulations/free-fall/js/ball.js
@@ -126,15 +126,13 @@ export class Ball {
     }
 
     // 状態表示
-    p.fill(255);
+    p.fill(0);
     p.noStroke();
     p.textAlign(p.RIGHT, p.TOP);
     p.textSize(18);
     const rightX = canvasHeight * (16 / 9) - 20;
     p.text(`時間: ${this.time.toFixed(2)} s`, rightX, 20);
-    p.text(`高さ: ${this.height.toFixed(2)} m`, rightX, 50);
-    p.text(`速度: ${this.velocity.toFixed(2)} m/s`, rightX, 80);
-    p.text(`初速: ${this.initialVelocity.toFixed(1)} m/s`, rightX, 110);
+    p.text(`速度: ${this.velocity.toFixed(2)} m/s`, rightX, 50);
   }
 
   /**

--- a/vite/simulations/free-fall/js/element-function.js
+++ b/vite/simulations/free-fall/js/element-function.js
@@ -34,8 +34,8 @@ export function onPlayPause() {
     state.ball.stop();
     state.playPauseButton.html("再開");
   } else {
-    if (state.ball.height <= 0) {
-      state.ball.reset(parseFloat(state.heightInput.value()));
+    if (state.ball.height <= 1) {
+      return;
     }
     state.ball.start();
     state.playPauseButton.html("一時停止");


### PR DESCRIPTION
## 本プルリクエストで実施したこと

- 高さの白かけに対応しました。
- 一時停止ボタンを押すと速度が上昇するバグに対応しました。

## 本プルリクエストで実施していないこと

なし

## 関連Issue、参考ページ

- #324 
