### PR TITLE
力と加速度の関係シミュレーションにおいて、最大値クリアボタンを追加し、最大値の履歴管理機能を実装

### DIFF
--- a/vite/simulations/force-and-acceleration/index.html
+++ b/vite/simulations/force-and-acceleration/index.html
@@ -47,6 +47,7 @@
       <!-- 左下コントロール -->
       <div class="left-bottom-controls">
         <button id="resetButton" class="btn btn-primary">リセット</button>
+        <button id="clearMaxButton" class="btn btn-secondary ms-2">最大値クリア</button>
       </div>
 
       <!-- 右上コントロール -->

--- a/vite/simulations/force-and-acceleration/js/class.js
+++ b/vite/simulations/force-and-acceleration/js/class.js
@@ -16,11 +16,20 @@ export class Cart {
     this.force = 0;
     this.acceleration = 0;
 
+    // 履歴としての最大値を保持する
+    this.maxForce = 0;
+    this.maxAcceleration = 0;
+    this.massAtMaxForce = mass;
+    this.massAtMaxAcceleration = mass;
+
     this.WHEEL_R = 28;
     this.BODY_W = 160;
     this.BODY_H = 55;
     this.BOX_W = 90;
     this.BOX_H = 70;
+
+    // 見た目の調整: 台車を地面にもう少し近づけるためのオフセット
+    this.groundOffset = 6;
   }
 
   /**
@@ -57,6 +66,16 @@ export class Cart {
     this.velocity += this.acceleration * dt;
     if (this.velocity < 0) this.velocity = 0;
     this.x += this.velocity * pxPerMeter * dt;
+
+    // 履歴としての最大値を更新（保持する）
+    if (this.force > this.maxForce) {
+      this.maxForce = this.force;
+      this.massAtMaxForce = this.mass;
+    }
+    if (this.acceleration > this.maxAcceleration) {
+      this.maxAcceleration = this.acceleration;
+      this.massAtMaxAcceleration = this.mass;
+    }
   }
 
   /**
@@ -70,7 +89,8 @@ export class Cart {
     const imgW = imgH * (cartImg.width / cartImg.height);
     this._displayW = imgW;
     const imgX = this.x - imgW / 2;
-    const imgY = groundY - imgH;
+    // 地面から少し下に描画して "浮いている" 印象を軽減する
+    const imgY = groundY - imgH + this.groundOffset;
     p.image(cartImg, imgX, imgY, imgW, imgH);
   }
 

--- a/vite/simulations/force-and-acceleration/js/element-function.js
+++ b/vite/simulations/force-and-acceleration/js/element-function.js
@@ -26,6 +26,18 @@ export function onReset() {
 }
 
 /**
+ * 最大値をクリアする処理
+ */
+export function onClearMax() {
+  if (!state.cart) return;
+  state.cart.maxForce = 0;
+  state.cart.maxAcceleration = 0;
+  // 最大値発生時の質量は現在の質量にリセット
+  state.cart.massAtMaxForce = state.cart.mass;
+  state.cart.massAtMaxAcceleration = state.cart.mass;
+}
+
+/**
  * 設定モーダルを開閉するときの処理
  */
 export function onToggleModal() {

--- a/vite/simulations/force-and-acceleration/js/index.js
+++ b/vite/simulations/force-and-acceleration/js/index.js
@@ -101,7 +101,10 @@ const sketch = (p) => {
       state.cart.force,
       state.cart.acceleration,
       state.cart.mass,
-      state.cart.velocity
+      state.cart.velocity,
+      state.cart.maxForce,
+      state.cart.maxAcceleration,
+      state.cart.massAtMaxAcceleration
     );
   };
 
@@ -211,25 +214,46 @@ function drawDragHint(p, x, y) {
  * @param {number} m  質量 (kg)
  * @param {number} v  現在の速度 (m/s)
  */
-function drawInfoPanel(p, F, a, m, v) {
+function drawInfoPanel(p, F, a, m, v, maxF, maxA, massAtMaxA) {
   p.fill(0, 0, 0, 180);
   p.stroke(255, 255, 255, 60);
   p.strokeWeight(1);
-  p.rect(20, 20, 290, 150, 10);
+  const panelX = 20;
+  const panelY = 20;
+  const panelW = 330;
+  const panelH = 150;
+  p.rect(panelX, panelY, panelW, panelH, 10);
 
   p.fill(255);
   p.noStroke();
   if (state.font) p.textFont(state.font);
-  p.textAlign(p.LEFT, p.TOP);
 
+  const leftX = panelX + 18;
+  const maxX = panelX + panelW - 18;
+
+  p.textAlign(p.LEFT, p.TOP);
   p.textSize(26);
-  p.text(`F = ${F.toFixed(2)} N`, 38, 34);
-  p.text(`a = ${a.toFixed(2)} m/s²`, 38, 74);
+  p.text(`F = ${F.toFixed(2)} N`, leftX, panelY + 14);
+  p.text(`a = ${a.toFixed(2)} m/s²`, leftX, panelY + 54);
+
+  // 最大値を右側に表示
+  p.textSize(18);
+  p.fill(230);
+  p.textAlign(p.RIGHT, p.TOP);
+  p.text(`${maxF.toFixed(2)} N (max)`, maxX, panelY + 14);
+  p.text(`${maxA.toFixed(2)} m/s² (max)`, maxX, panelY + 54);
+
+  // F = m * a を示す補助表示（最大加速度に対する力）
+  p.textAlign(p.LEFT, p.TOP);
+  p.textSize(14);
+  p.fill(200);
+  const fFromAMax = massAtMaxA && maxA ? massAtMaxA * maxA : 0;
+  p.text(`m × a_max = ${fFromAMax.toFixed(2)} N`, leftX, panelY + 94);
 
   p.textSize(20);
   p.fill(200);
-  p.text(`m = ${m.toFixed(1)} kg`, 38, 116);
-  p.text(`v = ${v.toFixed(2)} m/s`, 175, 116);
+  p.text(`m = ${m.toFixed(1)} kg`, leftX, panelY + 116);
+  p.text(`v = ${v.toFixed(2)} m/s`, leftX + 137, panelY + 116);
 }
 
 new p5(sketch);

--- a/vite/simulations/force-and-acceleration/js/init.js
+++ b/vite/simulations/force-and-acceleration/js/init.js
@@ -7,6 +7,7 @@ import {
   onReset,
   onToggleModal,
   onCloseModal,
+  onClearMax,
 } from "./element-function.js";
 
 export const FPS = 60;
@@ -30,6 +31,7 @@ export function settingInit(p, canvasController) {
 export function elementSelectInit(p) {
   state.massInput = p.select("#massInput");
   state.resetButton = p.select("#resetButton");
+  state.clearMaxButton = p.select("#clearMaxButton");
   state.toggleModal = p.select("#toggleModal");
   state.closeModal = p.select("#closeModal");
   state.settingsModal = p.select("#settingsModal");
@@ -42,6 +44,7 @@ export function elementSelectInit(p) {
 export function elementPositionInit(p) {
   state.massInput.input(onMassChange);
   state.resetButton.mousePressed(onReset);
+  if (state.clearMaxButton) state.clearMaxButton.mousePressed(onClearMax);
   state.toggleModal.mousePressed(onToggleModal);
   state.closeModal.mousePressed(onCloseModal);
 }

--- a/vite/simulations/force-and-acceleration/js/state.js
+++ b/vite/simulations/force-and-acceleration/js/state.js
@@ -14,6 +14,8 @@ export const state = {
   massInput: null,
   /** リセットボタン要素 */
   resetButton: null,
+  /** 最大値クリアボタン要素 */
+  clearMaxButton: null,
   /** 設定モーダル開閉ボタン要素 */
   toggleModal: null,
   /** 設定モーダル閉じるボタン要素 */


### PR DESCRIPTION
## 本プルリクエストで実施したこと

力と加速度の関係シミュレーションにおいて、最大値クリアボタンを追加し、最大値の履歴管理機能を実装しました。

## 本プルリクエストで実施していないこと

なし

## 関連Issue、参考ページ

- #341 
